### PR TITLE
Fix a few compiler warnings when using headers with MingW.

### DIFF
--- a/Open Steamworks/Interface_OSW.h
+++ b/Open Steamworks/Interface_OSW.h
@@ -113,6 +113,7 @@ public:
 #elif defined(__GNUC__)
 	#pragma GCC diagnostic push
 	#pragma GCC diagnostic ignored "-Wdeprecated"
+	#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
 		return GetSteam2Factory();

--- a/Open Steamworks/Interface_OSW.h
+++ b/Open Steamworks/Interface_OSW.h
@@ -112,7 +112,7 @@ public:
 	#pragma warning(disable: 4996)
 #elif defined(__GNUC__)
 	#pragma GCC diagnostic push
-	#pragma GCC disagnostic ignored "-Wdeprecated"
+	#pragma GCC diagnostic ignored "-Wdeprecated"
 #endif
 
 		return GetSteam2Factory();


### PR DESCRIPTION
This fixes a typo in a prama statement, and adds a suppression for what (newer versions of...?) GCC uses for deprecation warnings in that one inline compatibility function.
